### PR TITLE
update README to note Security Group ingress rule requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ Edit `index.html.md` to modify docs
 
 ## Deployment
 
-Push changes to remote then ssh into blog server. Pull the changes and run:
+Push changes to remote then ssh into blog server.
+
+Please note that to SSH in, you will need to add your IP address (eg. 1.2.3.4/32 tcp port 22) into the ingress rules for the EC2 instance.
+
+Pull the changes and run:
 
 ```sh
 cd HiveSdkDocs

--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ Edit `index.html.md` to modify docs
 
 Push changes to remote then ssh into blog server.
 
-Please note that to SSH in, you will need to add your IP address (eg. 1.2.3.4/32 tcp port 22) into the ingress rules for the EC2 instance.
+Please note that to SSH in, you will need to add your IP address (eg. 1.2.3.4/32 tcp port 22) into the ingress rules for the EC2 instance's security group.
+
+Security Group ID and name: sg-98203ffc - launch-wizard-4
+EC2 instance ID and name: i-043f38d4 (blog/sdk docs)
 
 Pull the changes and run:
 


### PR DESCRIPTION
<!--
⚠️ 🚨 ⚠️  STOP AND READ THIS ⚠️ 🚨 ⚠️

👆👆 see that 'base fork' dropdown above? You should change it! The default value of "lord/slate" submits your change to ALL USERS OF SLATE, not just your company. This is PROBABLY NOT WHAT YOU WANT.
-->

We had to remove ingress from 0.0.0.0/0 port 22 for this EC2 instance, so users will need to manually add their IP address to the ingress rules before they are able to SSH in.