### PR TITLE
INT-3766: chore: JS SDK: Document required Content Security Policy entries

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -51,23 +51,15 @@ To load the Hive SDK on your site, add the following script to your HTML:
 ```
   Content-Security-Policy:
   default-src 'self' data: blob: https:;
-  script-src 'self' 'unsafe-inline' 'unsafe-eval'
-    https://ajax.googleapis.com       # Required for jQuery
-    https://*.hive.co                 # Required for Hive SDK
-    # Your other script sources here
-  script-src-elem 'self' 'unsafe-inline' 'unsafe-eval'
-    https://ajax.googleapis.com
-    https://*.hive.co
-    # Your other script sources here
-  connect-src 'self' https:
-    https://*.hive.co
-    # Your other connect sources here
-  img-src 'self' data: blob: https:;
-  style-src 'self' 'unsafe-inline' https:;
-  font-src 'self' data: https:;
-  base-uri 'self';
-  frame-ancestors 'self';
-  upgrade-insecure-requests;
+  script-src 'self' https://ajax.googleapis.com https://*.hive.co
+    # Plus any of your other existing script sources.
+    ;
+  script-src-elem 'self' https://ajax.googleapis.com https://*.hive.co
+    # Plus any of your other existing script element sources.
+    ;
+  connect-src 'self' https://*.hive.co
+    # Plus any of your other existing API or data endpoints.
+    ;
 ```
 
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -40,6 +40,37 @@ To load the Hive SDK on your site, add the following script to your HTML:
 (function(h,i,v,e,s,d,k){h.HiveSDKObject=s;h[s]=h[s]||function(){(h[s].q=h[s].q||[]).push(arguments)},d=i.createElement(v),k=i.getElementsByTagName(v)[0];d.async=1;d.id=s;d.src=e+'?r='+parseInt(new Date()/60000);k.parentNode.insertBefore(d,k)})(window,document,'script','https://cdn-prod.hive.co/static/js/sdk-loader.js','HIVE_SDK')
 </script>
 ```
+<br/>
+<br/>
+<br/>
+<br/>
+<aside class='notice'>
+  Depending on your host's Content Security Policy (CSP) settings, you may need to update it to  allow scripts and network requests from Hive’s domains and its dependencies. Specifically `https://*.hive.co` and `https://ajax.googleapis.com` need to be whitelisted in order for the SDK to load properly. For example your CSP header might need to look like the following:
+</aside>
+
+```
+  Content-Security-Policy:
+  default-src 'self' data: blob: https:;
+  script-src 'self' 'unsafe-inline' 'unsafe-eval'
+    https://ajax.googleapis.com       # Required for jQuery
+    https://*.hive.co                 # Required for Hive SDK
+    # Your other script sources here
+  script-src-elem 'self' 'unsafe-inline' 'unsafe-eval'
+    https://ajax.googleapis.com
+    https://*.hive.co
+    # Your other script sources here
+  connect-src 'self' https:
+    https://*.hive.co
+    # Your other connect sources here
+  img-src 'self' data: blob: https:;
+  style-src 'self' 'unsafe-inline' https:;
+  font-src 'self' data: https:;
+  base-uri 'self';
+  frame-ancestors 'self';
+  upgrade-insecure-requests;
+```
+
+
 
 ## 3 - Initialize the SDK
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -51,18 +51,16 @@ To load the Hive SDK on your site, add the following script to your HTML:
 ```
   Content-Security-Policy:
   default-src 'self' data: blob: https:;
-  script-src 'self' https://ajax.googleapis.com https://*.hive.co
+  script-src 'self' 'unsafe-inline' https://ajax.googleapis.com https://*.hive.co
     # Plus any of your other existing script sources.
     ;
-  script-src-elem 'self' https://ajax.googleapis.com https://*.hive.co
+  script-src-elem 'self' 'unsafe-inline' https://ajax.googleapis.com https://*.hive.co
     # Plus any of your other existing script element sources.
     ;
   connect-src 'self' https://*.hive.co
     # Plus any of your other existing API or data endpoints.
     ;
 ```
-
-
 
 ## 3 - Initialize the SDK
 


### PR DESCRIPTION
<!-- [Docs on Pull Requests (PRs)](https://www.notion.so/hivealive/Pull-Requests-PRs-1b373434b83b8026b6ede87da4610e00) -->

## Linking

<!--
Link PR to Linear ticket using [Linear "magic words"](https://linear.app/docs/github?tabs=206cad22125a#link-using-pull-requests)

CLOSING MAGIC WORDS: close, closes, closed, closing fix, fixes, fixed, fixing, resolve, resolves, resolved, resolving, complete, completes, completed, completing

NON-CLOSING MAGIC WORDS: ref, references, part of, related to, contributes to, towards
-->

closes [INT-3766](https://linear.app/hiveco/issue/INT-3766/js-sdk-document-required-content-security-policy-entries)

## Description

Adding `<aside>` section the and CSP code example to the [load SDK section](https://sdk.hive.co/#2-load-the-sdk) in the docs.
## Manual Testing

Ran locally and confirmed visual.

## Visuals

<img width="1689" height="835" alt="image" src="https://github.com/user-attachments/assets/443a75f3-66e4-4c9e-9be9-391d7760a89d" />
